### PR TITLE
fix: fix file existence judgement

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -13,7 +13,8 @@ func Init(initialBranchName string) {
 
 	gitPath := path.Join(".", ".git")
 	absPath, _ := filepath.Abs(gitPath)
-	if _, err := os.Stat(gitPath); err != nil {
+	// if err == nil, file exists
+	if _, err := os.Stat(gitPath); err == nil {
 		fmt.Println("Reinitialized existing Git repository in " + absPath)
 		os.Exit(0)
 	}


### PR DESCRIPTION
Fixed an event in which .git was determined to exist even though it did not exist.